### PR TITLE
added: circleci: branches: only: master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ workflows:
           requires:
             - lint
           filters:
+            branches:
+              only:
+                - master
             tags:
               only: /^v/
       - cws/upload:


### PR DESCRIPTION
マージ前もビルドしようとしていて失敗していたため、
マージ後のみビルドするようにします。