### PR TITLE
changed: timeout: 30 -> 15

### DIFF
--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -161,9 +161,9 @@ async function fetchPage(url: string): Promise<Response> {
   try {
     await fetchSema.acquire();
     const abortController = new AbortController();
-    // ネットワーク通信は30秒でタイムアウト。
+    // ネットワーク通信は15秒でタイムアウト。
     // やたらと時間がかかるサイトはどうせろくでもないことが多い。
-    const timeout = setTimeout(() => abortController.abort(), 30 * 1000);
+    const timeout = setTimeout(() => abortController.abort(), 15 * 1000);
     try {
       return await fetch(url, {
         // 妙なリクエストを送らないように制限を加えます(こちらで書かないと変なこと起きないと思いますが)


### PR DESCRIPTION
3つ実行するなら長めでも良いかと思いましたが、
コンテンツ側で全て送り込んで制御しないので、
複数検索すると前の検索結果の取得を待たないと、
次の検索の結果のタイトルを取得できません。
よってタイムアウトを30秒から15秒に縮めます。

本当は見えているページのタイトル取得を優先するようにキューを作るべきなのかもしれません。
ページごとにツリーを変える幅優先的なアルゴリズムでうまくいく気がします。