### PR TITLE
fixed: selectLinkElements: 2段組にされている検索結果レイアウトに対応

### DIFF
--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -6,9 +6,7 @@ import { replaceLinkUrls } from "./url";
  * Googleの仕様変更に一番左右されそうな部分。
  */
 function selectLinkElements(el: Element): Element[] {
-  return Array.from(
-    el.querySelectorAll('.tF2Cxc .yuRUbf a[href^="http"]:not(.fl)')
-  );
+  return Array.from(el.querySelectorAll('.g .yuRUbf a[href^="http"]:not(.fl)'));
 }
 
 /** エントリーポイント。 */


### PR DESCRIPTION
二段組部分の所にはクラス指定などが無かったので、
クラス制約を少し緩めました。
試したら99件しかヒットしなかったので無駄に取っていることは無いと思います。