### PR TITLE
build(web-ext-config.js): delete global verbose

### DIFF
--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -11,7 +11,6 @@ const ignoreFiles = dir.filter(
 );
 
 module.exports = {
-  verbose: true,
   build: {
     overwriteDest: true,
     filename: "google-search-title-qualified.zip",


### PR DESCRIPTION
常に`verbose`はlintの時とかに流石に鬱陶しかった。