### PR TITLE
fix(esbuild): minifyをやめる

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "archive": "git archive HEAD --output=google-search-title-qualified.tar.gz",
-    "build": "ts-node manifest.json.make.ts && esbuild --bundle --outdir=dist --target=firefox102 --minify src/background/main.ts src/content/main.ts",
+    "build": "ts-node manifest.json.make.ts && esbuild --bundle --outdir=dist --target=firefox102 src/background/main.ts src/content/main.ts",
     "fix": "run-p --print-label fix:*",
     "fix:eslint": "yarn lint:eslint --fix",
     "fix:prettier": "yarn lint:prettier --write",


### PR DESCRIPTION
ネットワーク越しの読み込みならまだしろ、
ローカルでの読み込みにサイズをそこまで気にする必要はない。
それよりいざとなったときの可読性のほうが大事。

minifyしていた時。

~~~
  dist/background/main.js  327.3kb
  dist/content/main.js      42.9kb
~~~

minifyをやめた時。

~~~
  dist/background/main.js  666.9kb
  dist/content/main.js      89.9kb
~~~

で実はそこまで違いもない。