### PR TITLE
compatible to corepack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   nodejs:
     docker:
-      - image: cimg/node:18.13
+      - image: cimg/node:22.13
     working_directory: ~/google-search-title-qualified
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4",
     "web-ext": "^7.5.0"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "engines": {
+    "node": ">=22.13",
+    "yarn": ">=1.22.22"
   }
 }


### PR DESCRIPTION
- **build: corepackなどに対応した依存情報の追加**
- **ci(circleci): node イメージを 22.13 に更新**
