### PR TITLE
chore: dependabot設定ファイルを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Status: Review Needed"
+      - "Type: Dependencies"
+      - "Type: Maintenance"
+      - "Type: CI"
+      - "Type: Meta"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 20
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+      eslint:
+        patterns:
+          - "*eslint*"
+    labels:
+      - "Status: Review Needed"
+      - "Type: Dependencies"
+      - "Type: Maintenance"


### PR DESCRIPTION
GitHub Actionsとnpmの依存関係更新を自動化するため、
dependabot用の設定ファイル(`.github/dependabot.yml`)を追加。
