### PR TITLE
fix: `.g`セレクタを削除してリンク取得処理を修正

### DIFF
--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -23,7 +23,7 @@ function isValidURL(el: Element): boolean {
  */
 function selectLinkElements(el: Element): Element[] {
   return Array.from(
-    el.querySelectorAll('.g .yuRUbf a[href^="http"]:not(.fl)')
+    el.querySelectorAll('.yuRUbf a[href^="http"]:not(.fl)')
   ).filter(isValidURL);
 }
 


### PR DESCRIPTION
Googleの仕様変更によって`.g`セレクタが不要になったことに対応。
