### PR TITLE
ci: set read-only permissions for check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,8 @@
 name: check
 
+permissions:
+  contents: read
+
 on: push
 
 jobs:


### PR DESCRIPTION
CodeQLいわく明示的にGitHub Actionsのパーミッションを設定したほうが良いらしい。
