### PR TITLE
refactor(encoding): DOMParserを必要なときに必要な場所でのみ生成

### DIFF
--- a/src/background/extract-title.ts
+++ b/src/background/extract-title.ts
@@ -1,14 +1,43 @@
 import { convert } from "encoding-japanese";
-import type { Encoding } from "./encoding";
+import { detectEncoding, type Encoding } from "./encoding";
 
-/** バックグラウンドscript全体でDOMParserを使い回します。新規に生成していくのとどっちが早いのかは正直知りません。 */
-export const domParser = new DOMParser();
+/**
+ * ページの取得結果を受け取り、そのページのタイトルを抽出します。
+ * ページの取得結果の文字コードなどはまだ不明なので、blobを取得できるResponseを受け取ります。
+ */
+export async function extractTitle(
+  response: Response,
+): Promise<string | undefined> {
+  // `encodingJapanese`は`string`に完全になってない`Array`を要求するため、`blob`でレスポンスを消費します。
+  const blob = await response.blob();
+  const text = await blob.text();
+  const domParser = new DOMParser();
+  const dom = domParser.parseFromString(text, "text/html");
+  // エンコードを推定します。
+  const encoding = detectEncoding(response.headers, text);
+  // エンコードを取得できなかったら無を返します。
+  if (encoding == null) {
+    return undefined;
+  }
+  // UTF-8の場合変換は必要ありません。
+  if (encoding === "UTF8") {
+    return dom.querySelector("title")?.textContent ?? undefined;
+  }
+  // 他のエンコードでencoding-japaneseが対応しているものは変換を試みます。
+  if (["SJIS", "EUCJP"].includes(encoding)) {
+    return encodingJapaneseTitle(
+      new Uint8Array(await blob.arrayBuffer()),
+      encoding,
+    );
+  }
+  // 対応していないエンコードの場合は無を返します。
+  return undefined;
+}
 
-/** Uint8Arrayとして取り扱った非Unicode文字列をstringに戻すためのインスタンスを持ち回します。 */
-const utf8Decoder = new TextDecoder();
-
-/** encoding-japaneseが対応している文字コードのページのタイトルを取得します。 */
-export function encodingJapaneseTitle(
+/**
+ * encoding-japaneseが対応している文字コードのページのタイトルを取得します。
+ */
+function encodingJapaneseTitle(
   jp: Uint8Array,
   encoding: Encoding,
 ): string | undefined {
@@ -16,6 +45,8 @@ export function encodingJapaneseTitle(
     to: "UTF8",
     from: encoding,
   });
+  const domParser = new DOMParser();
+  const utf8Decoder = new TextDecoder();
   const dom = domParser.parseFromString(
     utf8Decoder.decode(new Uint8Array(utf8)),
     "text/html",

--- a/src/background/get-html-title.ts
+++ b/src/background/get-html-title.ts
@@ -1,49 +1,30 @@
-import { detectEncoding } from "./encoding";
-import { domParser, encodingJapaneseTitle } from "./extract-title";
+import { extractTitle } from "./extract-title";
 import { fetchPage } from "./fetch-page";
 
 /** URLからHTMLを取得解析してタイトルを取得します */
 export async function getHtmlTitle(url: string): Promise<string | undefined> {
   try {
-    // HTMLを取得、パースして結果を返す。
-    // 結果をまとめて加工したいため、内部関数に分ける。
-    const getText = async () => {
-      const response = await fetchPage(url);
-      if (!response.ok) {
-        throw new Error(
-          `${url}: response is not ok ${JSON.stringify(response.statusText)}`,
-        );
-      }
-      // encodingJapaneseはstringに完全になってないArrayを要求するため、blobでレスポンスを消費します。
-      const blob = await response.blob();
-      const text = await blob.text();
-      const dom = domParser.parseFromString(text, "text/html");
-      // エンコードを推定します。
-      const encoding = detectEncoding(response, dom);
-      // エンコードを取得できなかったら無を返します。
-      if (encoding == null) {
-        return undefined;
-      }
-      // UTF-8の場合変換は必要ありません。
-      if (encoding === "UTF8") {
-        return dom.querySelector("title")?.textContent ?? undefined;
-      }
-      // 他のエンコードでencoding-japaneseが対応しているものは変換を試みます。
-      if (["SJIS", "EUCJP"].includes(encoding)) {
-        return encodingJapaneseTitle(
-          new Uint8Array(await blob.arrayBuffer()),
-          encoding,
-        );
-      }
-      return undefined;
-    };
-    // titleソースコード周囲にある空白は除去。
-    // 改行は論理的な分割かもしれないし、
-    // HTMLソースの幅の問題かもしれないので空白に変換する。
-    return (await getText())?.trim().replaceAll(/\n+/g, " ");
+    const response = await fetchPage(url);
+    if (!response.ok) {
+      throw new Error(
+        `${url}: response is not ok ${JSON.stringify(response.statusText)}`,
+      );
+    }
+    const title = await extractTitle(response);
+    return title && cleanTitle(title);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error("getHtmlTitle error", err, url);
     return undefined;
   }
+}
+
+/**
+ * titleソースコード周囲にある空白を除去。
+ * 改行は論理的な分割かもしれないし、
+ * HTMLソースの幅の問題かもしれないので、
+ * 空白に変換します。
+ */
+function cleanTitle(title: string): string {
+  return title.trim().replaceAll(/\n+/g, " ");
 }

--- a/src/background/get-twitter.ts
+++ b/src/background/get-twitter.ts
@@ -1,5 +1,4 @@
 import * as t from "io-ts";
-import { domParser } from "./extract-title";
 import { fetchPage } from "./fetch-page";
 
 const twitterOembed = t.type({
@@ -42,6 +41,7 @@ export async function getTwitterTitle(
     if (!twitterOembed.is(j)) {
       return undefined;
     }
+    const domParser = new DOMParser();
     const dom = domParser.parseFromString(j.html, "text/html");
     // Twitterは改行などが反映されないと少し見苦しいので、
     // ちょっとした整形をする。


### PR DESCRIPTION
Manifest V3対応を見据えると、
一度必要な場所を明確にしたほうが良いので、
グローバルにインスタンスを持つのはやめておく。
元々別にグローバルでインスタンスを持つことのメリットは未検証で微妙でした。
