### PR TITLE
fix(fetch-page): fetchオプションをデフォルトに近づける

### DIFF
--- a/src/background/fetch-page.ts
+++ b/src/background/fetch-page.ts
@@ -23,6 +23,8 @@ export async function fetchPage(url: string): Promise<Response> {
     }, timeoutFetchNetwork);
     try {
       return await fetch(url, {
+        // 認証情報が不用意に送られないようにします。サイトの誤動作防止の意味が強い。
+        credentials: "omit",
         // タイムアウト中断コントローラ。
         signal: abortController.signal,
       });


### PR DESCRIPTION
Manifest V3での挙動が怪しいので、
あまりこちらで設定せずにデフォルトオプションに任せることにしました。
しょせんブラウザ拡張機能からのGETリクエストなので、
デフォルトオプションでそんなに危険なことには元々ならないはず。
